### PR TITLE
Make the asset dir easily configurable

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,13 +11,17 @@ const PORT = process.env.PORT || '8000';
 const USWDS_DIST = 'node_modules/uswds/dist';
 const USWDS_DIST_DIR = path.join(__dirname, ...USWDS_DIST.split('/'));
 
+// If moving assets to a sub-directory, change '.' to that sub-directory.
+// e.g. 'assets', or 'public/assets'.
+const ASSETS_DIR = path.join(__dirname, '.');
+
 gulp.task('copy-uswds-assets', () => {
   return gulp.src(`${USWDS_DIST}/@(js|fonts|img)/**/**`)
-  .pipe(gulp.dest('./vendor/uswds'));
+  .pipe(gulp.dest(`${ASSETS_DIR}/vendor/uswds`));
 });
 
 gulp.task('sass', () => {
-  return gulp.src('./sass/**/*.scss')
+  return gulp.src(`${ASSETS_DIR}/sass/**/*.scss`)
     .pipe(sourcemaps.init())
     .pipe(sass({
       includePaths: [
@@ -25,11 +29,11 @@ gulp.task('sass', () => {
       ]
     }).on('error', sass.logError))
     .pipe(sourcemaps.write())
-    .pipe(gulp.dest('./css'));
+    .pipe(gulp.dest(`${ASSETS_DIR}/css`));
 });
 
 gulp.task('sass:watch', () => {
-  gulp.watch('./sass/**/*.scss', ['sass']);
+  gulp.watch(`${ASSETS_DIR}/sass/**/*.scss`, ['sass']);
 });
 
 gulp.task('watch', ['default', 'sass:watch'], done => {


### PR DESCRIPTION
The asset directory in the gulpfile is effectively hardcoded to `.` and copied in a few different places.

This puts one place at the top of the gulpfile where the `ASSETS_DIR` can be changed to something other than `.`, for those projects where assets are stored inside of a sub-dir such as `static/` or `assets/` or `public/`, etc.

It doesn't change the CSS/JS paths in the HTML, so they still work, though obviously if someone were to change the `ASSETS_DIR`, they would need to update their include paths for the USWDS to still function, but that's a reasonable user responsibility.